### PR TITLE
feat(design): A2A protocol migration planning (Task 04)

### DIFF
--- a/docs/a2a-design/auditor-reliability.agent.json
+++ b/docs/a2a-design/auditor-reliability.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "auditor-reliability",
   "description": "信頼性監査担当エージェント。再現性（NFR-001）、テスト品質（NFR-020）、エラーハンドリング（P-010）の観点で独立監査する。Serena MCP を使用した条件付きセマンティック検証（第3層）を担う。コードは変更しない。",
-  "url": "http://localhost:8085/.well-known/agent.json",
+  "url": "http://127.0.0.1:8085/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": false,
@@ -53,6 +53,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": false,
     "delegationRole": "spoke",
     "invokedBy": ["Orchestrator"],

--- a/docs/a2a-design/auditor-security.agent.json
+++ b/docs/a2a-design/auditor-security.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "auditor-security",
   "description": "セキュリティ監査担当エージェント。禁止操作（P-001）、秘密情報禁止（P-002）、依存関係（P-040）の観点で独立監査する。コードは変更しない。最も制限されたツールセットを持つ。",
-  "url": "http://localhost:8084/.well-known/agent.json",
+  "url": "http://127.0.0.1:8084/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": false,
@@ -46,6 +46,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": false,
     "delegationRole": "spoke",
     "invokedBy": ["Orchestrator"],

--- a/docs/a2a-design/auditor-spec.agent.json
+++ b/docs/a2a-design/auditor-spec.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "auditor-spec",
   "description": "仕様監査担当エージェント。変更が requirements/policies/constraints/plan に整合しているかを独立監査する。コードは変更しない。",
-  "url": "http://localhost:8083/.well-known/agent.json",
+  "url": "http://127.0.0.1:8083/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": false,
@@ -46,6 +46,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": false,
     "delegationRole": "spoke",
     "invokedBy": ["Orchestrator"],

--- a/docs/a2a-design/implementer.agent.json
+++ b/docs/a2a-design/implementer.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "implementer",
   "description": "コード実装担当エージェント。Orchestrator からの指示に基づき、ソースコードと docs の更新を行う。Serena MCP を活用した Shift-Left セマンティック分析を実施し、結果を Orchestrator に返却する。",
-  "url": "http://localhost:8081/.well-known/agent.json",
+  "url": "http://127.0.0.1:8081/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": true,
@@ -46,6 +46,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": false,
     "delegationRole": "spoke",
     "invokedBy": ["Orchestrator"],

--- a/docs/a2a-design/migration-roadmap.md
+++ b/docs/a2a-design/migration-roadmap.md
@@ -101,12 +101,17 @@ Orchestrator → release-manager → (人間に直接報告)
 
 | # | 条件 | 判定基準 | 現状 |
 |---|---|---|---|
-| T-1 | A2A プロトコルの安定版リリース | v1.0 GA または主要クラウドプロバイダー※の本番採用 | v0.3（未達） |
+| T-1 | A2A プロトコルの安定版リリース | v1.0 GA または主要クラウドプロバイダー※の本番採用、または OSS 代替トリガー※※の達成 | v0.3（未達） |
 | T-2 | Python A2A SDK の成熟 | `a2a-python` SDK が安定版に到達 | 開発中（未達） |
 | T-3 | gRPC サポートの安定化 | v0.3 で追加された gRPC transport が本番利用可能 | 実験的（未達） |
 | T-4 | Agent Card 署名の標準化 | 署名検証ツールチェーンが整備 | 仕様策定中（未達） |
 
 > ※「主要クラウドプロバイダー」= AWS・Google Cloud・Azure のうち **2社以上** が A2A エージェントのマネージドサービスを本番提供していること。
+>
+> ※※ OSS 代替トリガー: プロジェクトが自律的に判断できる代替条件として、以下の **すべて** を満たす場合も T-1 を達成したものとみなす:
+> 1. A2A 互換の OSS 実装が Apache-2.0 など本プロジェクトで許容されたライセンスで公開されていること
+> 2. 当プロジェクトで PoC と負荷試験を実施し、要求される性能・信頼性・セキュリティ要件を満たすことを確認済みであること
+> 3. 当該 OSS 実装を前提とした運用手順と監視項目が `docs/runbook.md` に反映済みであること
 
 ### 2.2 プロジェクト的トリガー
 
@@ -183,7 +188,7 @@ flowchart TD
 | 2-5 | handoff パターンの A2A 化（`transfer` アクション） | 2-4 完了 |
 | 2-6 | ストリーミング対応（SSE → `tasks/sendSubscribe`） | 2-4 完了 |
 | 2-7 | 認証実装（Bearer トークン検証） | セキュリティ設計 |
-| 2-8 | Serena MCP 連携の A2A 経由化 | 2-4 完了, MCP 互換性確認 |
+| 2-8 | A2A エージェント環境での Serena MCP 連携動作確認 | 2-4 完了, MCP 互換性確認 |
 
 **切替戦略**: カナリアデプロイ方式。1エージェントずつ切り替え、問題がなければ次へ。
 
@@ -222,7 +227,7 @@ flowchart TD
 | R-2 | Copilot Extensions の突然の廃止 | 高 | 低 | Phase 1 を前倒しで準備し、デュアルスタック状態を確保する |
 | R-3 | A2A Python SDK の品質不足 | 中 | 中 | SDK に依存しない薄いラッパー層を設け、直接 HTTP 実装にフォールバック可能にする |
 | R-4 | Serena MCP と A2A の互換性問題 | 中 | 中 | MCP は A2A とは独立したプロトコル。Phase 2-8 で互換性を個別検証する |
-| R-5 | handoff パターンの A2A 未サポート | 中 | 低 | A2A v0.3 は `transfer` アクションを仕様に含む。未実装の場合は擬似 handoff（sub-agent + 制御フラグ）で代替する |
+| R-5 | handoff パターンの A2A 未サポート | 中 | 低 | A2A v0.3 における `transfer`（handoff 相当）アクションのサポート状況は公式ドキュメントおよび実装で要確認。未サポートまたは未実装の場合は擬似 handoff（sub-agent + 制御フラグ）で代替する |
 | R-6 | 認証・セキュリティの複雑化 | 中 | 中 | localhost 制約（P-001 相当）を維持。外部公開は ADR で別途判断する |
 | R-7 | 移行期間中の機能劣化 | 低 | 中 | デュアルスタック方式により、A2A 側に問題があれば即座に Copilot 側にフォールバック |
 
@@ -263,7 +268,7 @@ Phase 1〜3 の各ステップで問題が発生した場合のロールバッ�
 | `auditor-spec.agent.json` | auditor-spec | ❌ | sub-agent (spoke) |
 | `auditor-security.agent.json` | auditor-security | ❌ | sub-agent (spoke) |
 | `auditor-reliability.agent.json` | auditor-reliability | ❌ | sub-agent (spoke) |
-| `release-manager.agent.json` | release-manager | ✅ | handoff (terminal) |
+| `release-manager.agent.json` | release-manager | ❌ | handoff (terminal) |
 
 ## 付録 B: 用語集
 

--- a/docs/a2a-design/orchestrator.agent.json
+++ b/docs/a2a-design/orchestrator.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "Orchestrator",
   "description": "プロジェクトの司令塔エージェント。docs/plan.md の Next タスクを分解し、サブエージェントに委譲して結果を統合する。自らコードは書かず、パイプライン全体の指揮・統合を担う。",
-  "url": "http://localhost:8080/.well-known/agent.json",
+  "url": "http://127.0.0.1:8080/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": true,
@@ -16,6 +16,7 @@
     "organization": "dev-orchestration-template"
   },
   "supportsAuthenticatedExtendedCard": true,
+  "_supportsAuthenticatedExtendedCardNote": "Orchestrator のみが true。hub エージェントとして認証済みクライアントに拡張カード（managedAgents/handoffTargets 等）を提供するため。spoke エージェントは hub 経由でのみ呼び出されるため不要。",
   "skills": [
     {
       "id": "pipeline-execution",
@@ -61,6 +62,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": true,
     "delegationRole": "hub",
     "managedAgents": [

--- a/docs/a2a-design/release-manager.agent.json
+++ b/docs/a2a-design/release-manager.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "release-manager",
   "description": "リリース判定担当エージェント。全監査結果を統合し、受入条件（AC）をチェックして PR のマージ可否を判定する。コードは変更しない。Orchestrator からの handoff（一方向・制御移譲）で呼び出される。",
-  "url": "http://localhost:8086/.well-known/agent.json",
+  "url": "http://127.0.0.1:8086/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": false,
@@ -39,10 +39,12 @@
     }
   ],
   "_meta": {
-    "userInvokable": true,
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
+    "userInvokable": false,
     "delegationRole": "terminal",
     "invokedBy": ["Orchestrator"],
     "delegationMode": "handoff",
-    "handoffNote": "Orchestrator から制御ごと引き渡される一方向委譲。判定結果は人間に直接報告する。"
+    "handoffNote": "Orchestrator から制御ごと引き渡される一方向委譲。判定結果は人間に直接報告する。",
+    "pushNotificationsNote": "release-manager のみ pushNotifications: true。handoff terminal として判定結果（Approve/Request Changes/Pending）を人間に即座にプッシュ通知する必要があるため。Orchestrator は pushNotifications: true だが、これは hub としてパイプライン全体の進捗を人間に通知するため。spoke エージェントは hub 経由で結果を返すため pushNotifications は不要。"
   }
 }

--- a/docs/a2a-design/test-engineer.agent.json
+++ b/docs/a2a-design/test-engineer.agent.json
@@ -1,7 +1,7 @@
 {
   "name": "test-engineer",
   "description": "テスト担当エージェント。実装に対するテスト（単体/境界値/統合/再現性）を作成・実行し、品質を担保する。テストにはダミーデータのみ使用する。",
-  "url": "http://localhost:8082/.well-known/agent.json",
+  "url": "http://127.0.0.1:8082/.well-known/agent.json",
   "version": "1.0.0",
   "capabilities": {
     "streaming": true,
@@ -46,6 +46,7 @@
     }
   ],
   "_meta": {
+    "_note": "この _meta セクションは A2A v0.3 の標準仕様ではなく、本プロジェクト固有の拡張フィールドです。標準準拠の A2A クライアントはこのフィールドを無視してかまいません。",
     "userInvokable": false,
     "delegationRole": "spoke",
     "invokedBy": ["Orchestrator"],


### PR DESCRIPTION
## 概要
タスク04（A2A プロトコル移行計画の設計）の成果物をコミットするPRです。
コード変更は含まず、設計ドキュメントの追加のみです。

## 追加ファイル
| ファイル | 内容 |
|---|---|
| orchestrator.agent.json | Orchestrator の Agent Card（6スキル、user-invokable） |
| implementer.agent.json | Implementer の Agent Card（4スキル、spoke） |
| test-engineer.agent.json | Test Engineer の Agent Card（4スキル、spoke） |
| auditor-spec.agent.json | Auditor-Spec の Agent Card（4スキル、spoke） |
| auditor-security.agent.json | Auditor-Security の Agent Card（4スキル、spoke） |
| auditor-reliability.agent.json | Auditor-Reliability の Agent Card（5スキル、spoke） |
| release-manager.agent.json | Release Manager の Agent Card（3スキル、handoff terminal） |
| migration-roadmap.md | 段階的移行計画（差分分析・トリガー条件・リスク対応） |

## 設計上の重要な決定事項
- ACP（IBM BeeAI）は 2025-09-01 に A2A へ統合済みのため、A2A のみを対象とする
- 移行開始条件: 技術的トリガー T-1〜T-4 すべて AND プロジェクト的トリガー P-T1〜P-T3 のいずれか
- 現時点では全トリガーが「未達」のため移行は保留

## 対応要件
- MUST-01: A2A v0.3 準拠の Agent Card 7ファイル作成 ✅
- MUST-02: 移行ロードマップ策定 ✅
