### PR TITLE
fix: issue-lifecycle.yml の無効な permission 'projects: write' を削除

### DIFF
--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -12,7 +12,6 @@ permissions:
   issues: write
   contents: read
   pull-requests: read
-  projects: write
 
 concurrency:
   group: issue-lifecycle-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

`issue-lifecycle.yml` の `permissions` ブロックに存在する無効な `projects: write` を削除する。

## 変更内容

- `.github/workflows/issue-lifecycle.yml` の `permissions` から `projects: write` を削除

## 理由

GitHub Actions の有効な `permissions` スコープに `projects` は存在しない（[公式ドキュメント](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)参照）。

このため、`issue-lifecycle.yml` が含まれるブランチへの push 時に以下のバリデーションエラーが発生する：

```
Invalid workflow file: .github/workflows/issue-lifecycle.yml
(Line: 15, Col: 3): Unexpected value 'projects'
```

GitHub Projects v2 の操作には PAT（`project` スコープ）が必要であり、`GITHUB_TOKEN` の permission スコープでは制御できないため、この行は効果がなく、かつ CI エラーの原因となっている。

## 検証結果

- YAML 構文: valid
- ポリシーチェック: OK